### PR TITLE
Updated ready(...) function and mapAmplitudes(...), removing getInputBuffer().

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ AudioLab is a singleton instance of ClassAudioLab
 
 * **AudioLab.init**(void) - initialize AudioLab, call once in Arduino IDE `void setup()`
 
-* **bool AudioLab.ready**(void) - returns true when synthesis function should be called. Call this function continuously in Arduino IDE `void loop()` with `if (AudioLab.ready()) {...}` or `if (!AudioLab.ready()) return;`
+* **bool AudioLab.ready<typename>**(typename *buffer) - returns true when input buffer fills. Call this function continuously in Arduino IDE `void loop()` with `if (AudioLab.ready(...)) {...}` or `if (!AudioLab.ready(...)) return;` The buffer parameter is used to copy results from volatile buffer to non-volatile buffer. Buffer must be at least of size [NUM_IN_CH][WINDOW_SIZE].
+
+* **bool AudioLab.ready**(void) - use this definition of `AudioLab.ready()` if aquired signal isn't needed
 
 * **AudioLab.synthesize**(void) - synthesize signal for audio output, this function should be called once in `if (AudioLab.ready())` block (after waves are assigned)
 
@@ -42,8 +44,6 @@ AudioLab is a singleton instance of ClassAudioLab
 * **Wave AudioLab.dynamicWave**(uint8_t aChannel, WaveType aWaveType = SINE) - returns a pointer to wave object that will only exist in scope of `if (AudioLab.ready())` block
 
 * **AudioLab.changeWaveType**(Wave& aWave, WaveType aWaveType) - change the wave type of an existing wave
-
-* **uint16_t*** **AudioLab.getInputBuffer**(uint8_t aChannel = 0) - returns pointer to input buffer on a channel
 
 * **AudioLab.printWaves**(void) - prints information about waves that will be synthesized
 

--- a/examples/FrequencySweep/FrequencySweep.ino
+++ b/examples/FrequencySweep/FrequencySweep.ino
@@ -25,6 +25,7 @@ void loop() {
     // reset the frequency to 10Hz if it is more than or equal to AUD_OUT_SAMPLE_RATE, otherwise multiply the current frequency by 1.01
     if (aStaticWave->getFrequency() >= AUD_OUT_SAMPLE_RATE) aStaticWave->setFrequency(100);
     else aStaticWave->setFrequency(aStaticWave->getFrequency() * 1.001);
+    aStaticWave->setDuration(1);
 
     Serial.println(aStaticWave->getFrequency());
 

--- a/src/AudioLab.cpp
+++ b/src/AudioLab.cpp
@@ -34,7 +34,7 @@ void ClassAudioLab::init(void) {
 //   return;
 // }
 
-void ClassAudioLab::ready() {
+bool ClassAudioLab::ready(void) {
   if (!AUD_IN_BUFFER_FULL()) return false;
     // reset/synchronize input and output indexes to continue sampling
     SYNC_AUD_IN_OUT_IDX();

--- a/src/AudioLab.cpp
+++ b/src/AudioLab.cpp
@@ -2,7 +2,7 @@
 
 ClassAudioLab AudioLab;
 
-uint16_t ClassAudioLab::inputBuffer[NUM_IN_CH][AUD_IN_BUFFER_SIZE];
+// uint16_t ClassAudioLab::inputBuffer[NUM_IN_CH][AUD_IN_BUFFER_SIZE];
 
 void ClassAudioLab::init(void) {
   initAudio();
@@ -38,30 +38,30 @@ void ClassAudioLab::init(void) {
  * returns true once WINDOW_SIZE samples is sampled but first samples from volatile buffer are copied to non-volatile
  * buffer, then input and buffer indexes are synchronized and dynamic waves are removed for next synthesis cycle
  */
-bool ClassAudioLab::ready(void) {
-  if (!AUD_IN_BUFFER_FULL()) return false;
+// bool ClassAudioLab::ready(void) {
+//   if (!AUD_IN_BUFFER_FULL()) return false;
 
-  // store samples from volatile input buffer to non-volatile buffer
-  uint16_t c, i;
-  for (c = 0; c < NUM_IN_CH; c++) {
-    for (i = 0; i < WINDOW_SIZE; i++) {
-      inputBuffer[c][i] = AUD_IN_BUFFER[c][i];
-    }
-  }
+//   // store samples from volatile input buffer to non-volatile buffer
+//   uint16_t c, i;
+//   for (c = 0; c < NUM_IN_CH; c++) {
+//     for (i = 0; i < WINDOW_SIZE; i++) {
+//       inputBuffer[c][i] = AUD_IN_BUFFER[c][i];
+//     }
+//   }
 
-  // reset/synchronize input and output indexes to continue sampling
-  SYNC_AUD_IN_OUT_IDX();
+//   // reset/synchronize input and output indexes to continue sampling
+//   SYNC_AUD_IN_OUT_IDX();
 
-  // free generateAudioWaveList
-  for (c = 0; c < NUM_OUT_CH; c++) {
-    freeWaveList(generateAudioWaveList[c]);
-  }
+//   // free generateAudioWaveList
+//   for (c = 0; c < NUM_OUT_CH; c++) {
+//     freeWaveList(generateAudioWaveList[c]);
+//   }
   
-  // remove dynamic waves
-  removeDynamicWaves();
+//   // remove dynamic waves
+//   removeDynamicWaves();
 
-  return true;
-}
+//   return true;
+// }
 
 /*
  * Takes the sum of amplitudes in a channel and divides by a minimum value but, if the amplitude sum exceeds the minimum 
@@ -176,13 +176,13 @@ void ClassAudioLab::changeWaveType(Wave& aWave, WaveType aWaveType) {
   aWave = _newWave;
 }
 
-uint16_t *ClassAudioLab::getInputBuffer(uint8_t aChannel) {
-  if (!(aChannel >= 0 && aChannel < NUM_IN_CH)) {
-    // DBG_printf("INVALID INPUT CHANNEL %d, USE RANGE BETWEEN [0..NUM_IN_CH)\r\n", aChannel);
-    return NULL;
-  }
-  return inputBuffer[aChannel];
-}
+// uint16_t *ClassAudioLab::getInputBuffer(uint8_t aChannel) {
+//   if (!(aChannel >= 0 && aChannel < NUM_IN_CH)) {
+//     // DBG_printf("INVALID INPUT CHANNEL %d, USE RANGE BETWEEN [0..NUM_IN_CH)\r\n", aChannel);
+//     return NULL;
+//   }
+//   return inputBuffer[aChannel];
+// }
 
 void ClassAudioLab::printWaves(void) {
   bool _return = 1;

--- a/src/AudioLab.cpp
+++ b/src/AudioLab.cpp
@@ -34,34 +34,21 @@ void ClassAudioLab::init(void) {
 //   return;
 // }
 
-/*
- * returns true once WINDOW_SIZE samples is sampled but first samples from volatile buffer are copied to non-volatile
- * buffer, then input and buffer indexes are synchronized and dynamic waves are removed for next synthesis cycle
- */
-// bool ClassAudioLab::ready(void) {
-//   if (!AUD_IN_BUFFER_FULL()) return false;
+void ClassAudioLab::ready() {
+  if (!AUD_IN_BUFFER_FULL()) return false;
+    // reset/synchronize input and output indexes to continue sampling
+    SYNC_AUD_IN_OUT_IDX();
 
-//   // store samples from volatile input buffer to non-volatile buffer
-//   uint16_t c, i;
-//   for (c = 0; c < NUM_IN_CH; c++) {
-//     for (i = 0; i < WINDOW_SIZE; i++) {
-//       inputBuffer[c][i] = AUD_IN_BUFFER[c][i];
-//     }
-//   }
+    // free generateAudioWaveList
+    for (uint16_t c = 0; c < NUM_OUT_CH; c++) {
+      freeWaveList(generateAudioWaveList[c]);
+    } 
+    
+    // remove dynamic waves
+    removeDynamicWaves();
 
-//   // reset/synchronize input and output indexes to continue sampling
-//   SYNC_AUD_IN_OUT_IDX();
-
-//   // free generateAudioWaveList
-//   for (c = 0; c < NUM_OUT_CH; c++) {
-//     freeWaveList(generateAudioWaveList[c]);
-//   }
-  
-//   // remove dynamic waves
-//   removeDynamicWaves();
-
-//   return true;
-// }
+    return true;
+}
 
 /*
  * Takes the sum of amplitudes in a channel and divides by a minimum value but, if the amplitude sum exceeds the minimum 

--- a/src/AudioLab.h
+++ b/src/AudioLab.h
@@ -98,14 +98,21 @@ class ClassAudioLab
      */
     void init();
 
-    // reset AudioLab (WIP)
-    // void reset();
+    /**
+     * Returns true when synthesis should occur
+     *
+     * @return true if AudioLab is ready for synthesis, otherwise false
+     * @note this definition should be used if ADC samples are not needed
+     */
+    bool ready(void);
+
 
     /**
      * Returns true when input buffer fills with ADC samples and synthesis should occur
      *
      * @param buffer buffer to copy samples to, must be of size [NUM_IN_CH][WINDOW_SIZE]
      * @return true if AudioLab is ready for synthesis, otherwise false
+     * @note use this definition if aquiring samples from ADC
      *
      */
     template <typename T>
@@ -134,13 +141,6 @@ class ClassAudioLab
       return true;
     };
 
-    /**
-     * Returns true when input buffer fills and synthesis should occur
-     *
-     * @return true if AudioLab is ready for synthesis, otherwise false
-     * @note this definition should be used if ADC samples are not needed
-     */
-    bool ready(void);
 
     /**
      * Linearly maps amplitudes of all waves on a channel so their sum will be

--- a/src/AudioLab.h
+++ b/src/AudioLab.h
@@ -102,8 +102,9 @@ class ClassAudioLab
     // void reset();
 
     /**
-     * Returns true when input buffer fills and synthesis should occur
+     * Returns true when input buffer fills with ADC samples and synthesis should occur
      *
+     * @param buffer buffer to copy samples to, must be of size [NUM_IN_CH][WINDOW_SIZE]
      * @return true if AudioLab is ready for synthesis, otherwise false
      *
      */
@@ -111,8 +112,8 @@ class ClassAudioLab
     bool ready(T *buffer) {
       if (!AUD_IN_BUFFER_FULL()) return false;
 
-      // store samples from volatile input buffer to non-volatile buffer
       uint16_t c, i;
+      // store samples from volatile input buffer to non-volatile buffer
       for (c = 0; c < NUM_IN_CH; c++) {
         for (i = 0; i < WINDOW_SIZE; i++) {
           buffer[c * WINDOW_SIZE + i] = AUD_IN_BUFFER[c][i];
@@ -132,6 +133,14 @@ class ClassAudioLab
 
       return true;
     };
+
+    /**
+     * Returns true when input buffer fills and synthesis should occur
+     *
+     * @return true if AudioLab is ready for synthesis, otherwise false
+     * @note this definition should be used if ADC samples are not needed
+     */
+    bool ready(void);
 
     /**
      * Linearly maps amplitudes of all waves on a channel so their sum will be

--- a/src/AudioLab.h
+++ b/src/AudioLab.h
@@ -116,14 +116,14 @@ class ClassAudioLab
      *
      */
     template <typename T>
-    bool ready(T *buffer) {
+    bool ready(T *buffer, uint16_t bufferSize = WINDOW_SIZE) {
       if (!AUD_IN_BUFFER_FULL()) return false;
 
       uint16_t c, i;
       // store samples from volatile input buffer to non-volatile buffer
       for (c = 0; c < NUM_IN_CH; c++) {
         for (i = 0; i < WINDOW_SIZE; i++) {
-          buffer[c * WINDOW_SIZE + i] = AUD_IN_BUFFER[c][i];
+          buffer[c * bufferSize + i] = AUD_IN_BUFFER[c][i];
         }
       }
 
@@ -147,8 +147,9 @@ class ClassAudioLab
      * less than or equal to 1.0.
      * @param aChannel channel of the waves to be mapped
      * @param aMin the minumum value to use for mapping, if amplitude sum surpasses this value then the amplitude sum will be used.
+     * @param smoothing amplitude smoothing (blending current sum with previous sum), must be in the [0, 1.0] range
      */
-    void mapAmplitudes(uint8_t aChannel, float aMin);
+    void mapAmplitudes(uint8_t aChannel, float aMin, float smoothing = 0.0);
 
     /**
      * Fills output buffer with synthesized signal composed of assigned waves

--- a/src/AudioLabSettings.h
+++ b/src/AudioLabSettings.h
@@ -38,7 +38,7 @@
 #define IN_PIN_CH2 A3       
 
 /******************************** AD56X4 DAC SETTINGS ********************************/
-#define USING_AD56X4_DAC    // Uncomment if using AD5644 SPI DAC
+// #define USING_AD56X4_DAC    // Uncomment if using AD5644 SPI DAC
 
 #if defined(USING_AD56X4_DAC)
 #define DAC_RESOLUTION 16   // The AD56X4 comes in 3 versions: 12, 14 and 16 bit

--- a/src/AudioLabSettings.h
+++ b/src/AudioLabSettings.h
@@ -27,11 +27,11 @@
 #endif                      // see AudioInputOutput.cpp
 
 #ifndef WINDOW_SIZE
-#define WINDOW_SIZE 256
+#define WINDOW_SIZE 128
 #endif
 
 /******************************** FEATHER ADC PINS ********************************/
-#define NUM_IN_CH 2         // Number of input channels to sample (Limit is 2, but adding more is fairly straightforward)
+#define NUM_IN_CH 1         // Number of input channels to sample (Limit is 2, but adding more is fairly straightforward)
                             // See AudioInputOutput.cpp
 
 #define IN_PIN_CH1 A2       


### PR DESCRIPTION
The AudioLab.ready() function is modified to store results directly to a passed buffer rather than storing to an internal buffer to conserve memory. Rather than using AudioLab.getInputBuffer(), which is now removed, you now must pass a user defined buffer of any datatype.

For example: AudioLab.ready<float>(buffer). You may also specify buffer size if your buffer is greater than WINDOW_SIZE for example AudioLab.ready<float>(buffer, bufferSize). However, note that your buffer must be AT LEAST WINDOW_SIZE in length.

If ADC data is not needed use AudioLab.ready() without any parameters and without specifying type, same as before.

The mapAmplitudes(...) function has an additional parameter "smoothing." This is used to smoothen amplitude transitions with previous amplitude sums. The smoothing parameter defaults to 0, and must be [0, 1.0] range.